### PR TITLE
Expose full vcenter config directly (bucc should not care)

### DIFF
--- a/ops/cpis/vsphere/cpi-config.yml
+++ b/ops/cpis/vsphere/cpi-config.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /instance_groups/name=bosh/properties/vcenter?
+  value: ((vcenter))
+
+- type: replace
+  path: /cloud_provider/properties/vcenter?
+  value: ((vcenter))

--- a/ops/cpis/vsphere/resource-pool.yml
+++ b/ops/cpis/vsphere/resource-pool.yml
@@ -1,8 +1,0 @@
----
-- type: replace
-  path: /instance_groups/name=bosh/properties/vcenter/datacenters/name=((vcenter_dc))/clusters/0/((vcenter_cluster))/resource_pool?
-  value: ((vcenter_rp))
-
-- type: replace
-  path: /cloud_provider/properties/vcenter/datacenters/name=((vcenter_dc))/clusters/0/((vcenter_cluster))/resource_pool?
-  value: ((vcenter_rp))

--- a/ops/cpis/vsphere/thin-disks.yml
+++ b/ops/cpis/vsphere/thin-disks.yml
@@ -1,7 +1,0 @@
-- type: replace
-  path: /instance_groups/name=bosh/properties/vcenter/default_disk_type?
-  value: thin
-
-- type: replace
-  path: /cloud_provider/properties/vcenter/default_disk_type?
-  value: thin

--- a/ops/cpis/vsphere/vars.tmpl
+++ b/ops/cpis/vsphere/vars.tmpl
@@ -1,16 +1,21 @@
-director_name:
-internal_cidr:
-internal_gw:
-internal_ip:
-network_name:
-vcenter_cluster:
-vcenter_dc:
-vcenter_disks:
-vcenter_dns:
-vcenter_ds:
-vcenter_ip:
-vcenter_password:
-vcenter_rp:
-vcenter_templates:
-vcenter_user:
-vcenter_vms:
+director_name: bosh
+internal_cidr: 10.0.0.0/24
+internal_gw: 10.0.0.1
+internal_ip: 10.0.0.2
+network_name: network1
+vcenter_dns: [ 8.8.8.8 ]
+vcenter:
+  address: example.com # ip or hostname (should be resolvable by vcenter_dns)
+  password: password
+  user: admin
+  default_disk_type: thin
+  datacenters:
+  - name: datacenter1
+    datastore_pattern: volume1|volume2
+    disk_path: bucc
+    persistent_datastore_pattern: volume1|volume2
+    template_folder: bucc/templates
+    vm_folder: bucc/vms
+    clusters:
+    - cluster1: {}
+    #    resource_pool: pool1


### PR DESCRIPTION
This change was made because I ran into a situation where we had an vCenter environment without resource pools. With the previous setup I was unable to get it to work.

An other problem I encountered was that var names did not corresponded to the cpi config. Which made it harder to figure out what should go where. By exposing the cpi config directly people can refer to the cpi documentation directly.