### PR TITLE
Use git to get the toplevel

### DIFF
--- a/bin/bucc
+++ b/bin/bucc
@@ -1,7 +1,6 @@
 #!/bin/bash
 version=$(grep bucc .versions | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')
 
-repo_root=$(dirname $(realpath "$0") | rev | cut -c5- | rev)
 repo_root=$(git rev-parse --show-toplevel)
 state=${repo_root}/state
 mkdir -p $state/manifests

--- a/bin/bucc
+++ b/bin/bucc
@@ -2,6 +2,7 @@
 version=$(grep bucc .versions | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')
 
 repo_root=$(dirname $(realpath "$0") | rev | cut -c5- | rev)
+repo_root=$(git rev-parse --show-toplevel)
 state=${repo_root}/state
 mkdir -p $state/manifests
 manifest="${repo_root}/src/bosh-deployment/bosh.yml"


### PR DESCRIPTION
Changed code to use git to get the toplevel absolute directory instead of using $0 since $0 could have arbitrary values like "-bash"

Fixes #46