### PR TITLE
set PATH all the time when using bucc env

### DIFF
--- a/bin/bucc
+++ b/bin/bucc
@@ -248,10 +248,10 @@ get_var() {
 }
 
 env() {
+    echo "export PATH=${PATH}"
     if [[ ! -f ${vars_store} ]]; then
         exit 0
     fi
-    echo "export PATH=${PATH}"
     echo "export BOSH_ENVIRONMENT=$(get_var bosh_target)"
     echo "export BOSH_CA_CERT='$(cat $(ca_cert))'"
     echo "export BOSH_CLIENT=$(get_var bosh_client)"


### PR DESCRIPTION
Moved the PATH export line to before the test for credentials file.

Fixes Issue #50 