### PR TITLE
BREAKING - use hypens instead of underscores

### DIFF
--- a/ci/assets/acceptance-pipeline.yml
+++ b/ci/assets/acceptance-pipeline.yml
@@ -7,7 +7,7 @@ jobs:
     - get: docker-release
   - put: cloud-config
     params:
-      manifest: bosh-deployment/warden/cloud-config.yml
+      manifest: bosh-deployment/((bosh-cpi))/cloud-config.yml
       releases: []
   - put: deploy
     params:
@@ -26,15 +26,15 @@ resources:
   source:
     uri: https://github.com/cloudfoundry-community/docker-boshrelease.git
     branch: master
-    
+
 - name: stemcell
   type: bosh-io-stemcell
   source:
-    name: bosh-warden-boshlite-ubuntu-trusty-go_agent
+    name: ((bosh-stemcell))
 
 - name: deploy
   type: bosh-deployment
-  source: 
+  source:
     <<: *deployment
     <<: *bosh_env
 
@@ -46,11 +46,11 @@ resources:
 
 params:
   bosh_env: &bosh_env
-    target: ((bosh_environment))
-    client: ((bosh_client))
-    client_id: ((bosh_client))
-    client_secret: ((bosh_client_secret))
-    ca_cert: ((bosh_ca_cert))
+    target: ((bosh-environment))
+    client: ((bosh-client))
+    client_id: ((bosh-client))
+    client_secret: ((bosh-client_secret))
+    ca_cert: ((bosh-ca-cert))
   deployment: &deployment
     deployment: docker-swarm
 
@@ -66,4 +66,3 @@ resource_types:
   source:
     repository: cloudfoundry/bosh-deployment-resource
     tag: latest
-

--- a/ops/4-credhub-importer.yml
+++ b/ops/4-credhub-importer.yml
@@ -19,21 +19,6 @@
         ca_cert: ((credhub_tls.ca))((uaa_ssl.ca))
         import_credentials:
         # BOSH
-        - name: concourse/main/bosh_name
-          type: value
-          value: ((director_name))
-        - name: concourse/main/bosh_environment
-          type: value
-          value: ((internal_ip))
-        - name: concourse/main/bosh_ca_cert
-          type: value
-          value: ((director_ssl.ca))
-        - name: concourse/main/bosh_client_secret
-          type: value
-          value: ((admin_password))
-        - name: concourse/main/bosh_client
-          type: value
-          value: admin
         - name: concourse/main/bosh-name
           type: value
           value: ((director_name))
@@ -49,27 +34,13 @@
         - name: concourse/main/bosh-client
           type: value
           value: admin
-
         - name: concourse/main/bosh-cpi
           type: value
           value: ((shouldbereplaced))
         - name: concourse/main/bosh-stemcell
           type: value
           value: ((shouldbereplaced))
-
         # Credhub
-        - name: concourse/main/credhub_url
-          type: value
-          value: https://((internal_ip)):8844
-        - name: concourse/main/credhub_username
-          type: value
-          value: credhub-cli
-        - name: concourse/main/credhub_password
-          type: value
-          value: ((credhub_cli_password))
-        - name: concourse/main/credhub_ca_cert
-          type: value
-          value: ((uaa_ssl.ca))((credhub_tls.ca))
         - name: concourse/main/credhub-url
           type: value
           value: https://((internal_ip)):8844
@@ -83,18 +54,6 @@
           type: value
           value: ((uaa_ssl.ca))((credhub_tls.ca))
         # Concourse
-        - name: concourse/main/concourse_url
-          type: value
-          value: https://((internal_ip))
-        - name: concourse/main/concourse_username
-          type: value
-          value: admin
-        - name: concourse/main/concourse_password
-          type: value
-          value: ((ui_password))
-        - name: concourse/main/concourse_ca_cert
-          type: value
-          value: ((atc_ssl.ca))
         - name: concourse/main/concourse-url
           type: value
           value: https://((internal_ip))
@@ -112,7 +71,7 @@
   path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/scim/users?/-
   value:
     name: credhub-importer
-    password: ((credhub_importer_password))
+    password: ((credhub-importer-password))
     groups:
     - credhub.read
     - credhub.write
@@ -120,5 +79,5 @@
 - type: replace
   path: /variables/-
   value:
-    name: credhub_importer_password
+    name: credhub-importer-password
     type: password


### PR DESCRIPTION
this can be a breaking change for users who wrote there own pipelines for bucc.
this only happens when they reinstall bucc not on upgrade
