### PR TITLE
ntp flag file openstack missing values

### DIFF
--- a/ops/cpis/openstack/flags/ntp.yml
+++ b/ops/cpis/openstack/flags/ntp.yml
@@ -1,3 +1,6 @@
 - type: replace
   path: /cloud_provider/properties/ntp
   value: ((ntp))
+- type: replace
+  path: /instance_groups/name=bosh/properties/ntp
+  value: ((ntp))


### PR DESCRIPTION
/instance_groups/name=bosh/properties/ntp 

is not set via ntp.flag file