### PR TITLE
added escaped quotes to the env function.

### DIFF
--- a/bin/bucc
+++ b/bin/bucc
@@ -277,7 +277,7 @@ get_var() {
 }
 
 env() {
-    echo "export PATH=${PATH}"
+    echo "export PATH=\"${PATH}\""
     if [[ ! -f ${vars_store} ]]; then
         exit 0
     fi


### PR DESCRIPTION
on my system (macOS) when using direnv and bucc i get the following error:

direnv: loading .envrc
installing bosh cli '2.0.48' into: /Users/martincaarels/Development/bucc/bin/
direnv: ([direnv export zsh]) is taking a while to execute. Use CTRL-C to give up.
./.envrc: line 3: export: `Fusion.app/Contents/Public:/usr/local/go/bin:/Users/martincaarels/.rvm/bin': not a valid identifier

the problem is that in my current path there is a space:

/Users/martincaarels/.rvm/gems/ruby-2.4.1/bin:/Users/martincaarels/.rvm/gems/ruby-2.4.1@global/bin:/Users/martincaarels/.rvm/rubies/ruby-2.4.1/bin:/Library/Frameworks/Python.framework/Versions/3.6/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/go/bin:/Users/martincaarels/.rvm/bin

notice the disgusting space in "VMware Fusion.app"

this breaks the export in bucc env.

I've fixed this by adding escaped double qoutes to the bucc env function.

The path now includes bucc/bin, and direnv no longer breaks when entering the bucc repo.

hope this helps.