### PR TITLE
Override the fly_target/bosh_alias when setting up local CLI

### DIFF
--- a/bin/bucc
+++ b/bin/bucc
@@ -270,10 +270,24 @@ var_cache=${state}/vars_cache.yml
 rm -f ${var_cache}
 
 get_var() {
+    path=$1
     if [[ ! -f ${var_cache} ]]; then
         vars > ${var_cache}
     fi
-    bosh int ${var_cache} --path /$1
+    bosh int ${var_cache} --path "/$path"
+}
+
+get_var_with_default() {
+    path=$1
+    default_value=$2
+    if [[ ! -f ${var_cache} ]]; then
+        vars > ${var_cache}
+    fi
+    if [[ -n $(cat ${var_cache} | grep "$path:") ]]; then
+        bosh int ${var_cache} --path "/$path"
+    else
+        echo "${default_value}"
+    fi
 }
 
 env() {
@@ -321,12 +335,18 @@ _fly() {
         popd
     fi
 
-    faketty fly --target bucc login \
+    fly_target=$(get_var_with_default "fly_target" "bucc")
+
+    faketty fly --target "${fly_target}" login \
             --concourse-url ${url} \
             --username $(get_var concourse_username) \
             --password $(get_var concourse_password) \
             --team-name main \
             --ca-cert $(ca_cert)
+
+    echo "Example fly commands:"
+    echo "  fly -t ${fly_target} pipelines"
+    echo "  fly -t ${fly_target} builds"
 }
 
 _bosh() {
@@ -334,13 +354,15 @@ _bosh() {
     unset BOSH_CA_CERT
     unset BOSH_CLIENT
     unset BOSH_CLIENT_SECRET
-    bosh alias-env bucc \
+
+    bosh_alias=$(get_var_with_default "bosh_alias" "bucc")
+
+    bosh alias-env "$bosh_alias" \
                 --environment $(get_var bosh_target) \
                 --ca-cert "$(cat $(ca_cert))"
 
     printf '%s\n%s\n' $(get_var bosh_client) $(get_var bosh_client_secret) | \
-        bosh log-in -e bucc
-
+        bosh log-in -e "$bosh_alias"
 }
 
 _credhub() {

--- a/ops/cpis/aws/vars.tmpl
+++ b/ops/cpis/aws/vars.tmpl
@@ -16,3 +16,6 @@ ephemeral_disk_size: 25_000
 
 # flag: --spot-instance
 spot_bid_price: # Bid price in dollars for AWS spot instance
+
+fly_target: bucc
+bosh_alias: bucc

--- a/ops/cpis/azure/vars.tmpl
+++ b/ops/cpis/azure/vars.tmpl
@@ -11,3 +11,6 @@ subnet_name:
 subscription_id:
 tenant_id:
 vnet_name:
+
+fly_target: bucc
+bosh_alias: bucc

--- a/ops/cpis/gcp/vars.tmpl
+++ b/ops/cpis/gcp/vars.tmpl
@@ -11,3 +11,6 @@ zone: # us-east-1
 
 # flag: --service-account
 service_account: # service-account
+
+fly_target: bucc
+bosh_alias: bucc

--- a/ops/cpis/openstack/vars.tmpl
+++ b/ops/cpis/openstack/vars.tmpl
@@ -15,6 +15,9 @@ openstack_username:
 private_key:
 region:
 
+fly_target: bucc
+bosh_alias: bucc
+
 # flag: --dns
 dns: # [ 8.8.4.4 ]
 

--- a/ops/cpis/softlayer/vars.tmpl
+++ b/ops/cpis/softlayer/vars.tmpl
@@ -9,3 +9,6 @@ sl_vlan_public:
 sl_vlan_private:
 sl_username:
 sl_api_key:
+
+fly_target: bucc
+bosh_alias: bucc

--- a/ops/cpis/vsphere/vars.tmpl
+++ b/ops/cpis/vsphere/vars.tmpl
@@ -18,3 +18,6 @@ vcenter_dns: # [ 8.8.4.4 ]
 
 # flag: --resource-pool
 vcenter_rp: # my-bosh-rp
+
+fly_target: bucc
+bosh_alias: bucc


### PR DESCRIPTION
By default, `bucc fly` will continue to set `fly -t bucc`, and
`bucc bosh` will continue to create `bosh alias-env bucc`.

They can be override in `vars.yml` by `fly_target` and `bosh_alias`
respectively.