### PR TITLE
Deploy on Azure without requiring a pre-existing Storage Account

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ bucc up --help
   --proxy
 
   Optional cpi specific flags:
+    azure: --managed-disks
     gcp: --service-account
     softlayer: --cpi-dynamic
     openstack: --custom-ca --disk-az --dns --ignore-server-availability-zone --keystone-v2 --ntp --root-disk-size --trusted-certs

--- a/ops/cpis/azure/flags/managed-disks.yml
+++ b/ops/cpis/azure/flags/managed-disks.yml
@@ -1,0 +1,1 @@
+../../../../src/bosh-deployment/azure/use-managed-disks.yml


### PR DESCRIPTION
Hi Ruben,

In this PR I add a new `--managed-disk` flag that is convenient when deploying to Azure, because no Storage Account needs to be created first (and creating a Storage Account is actually painful).

Cheers,
Benjamin