### PR TITLE
Added global ops-file for setting concourse_lb_url

### DIFF
--- a/ops/3-concourse.yml
+++ b/ops/3-concourse.yml
@@ -5,7 +5,7 @@
     release: concourse
     properties:
       token_signing_key: ((token_signing_key))
-      external_url: &external_url https://((internal_ip))
+      external_url: https://((internal_ip))
       basic_auth_username: admin
       basic_auth_password: ((ui_password))
       generic_oauth:

--- a/ops/flags/concourse-lb-url.yml
+++ b/ops/flags/concourse-lb-url.yml
@@ -1,0 +1,29 @@
+# Concourse
+- type: replace
+  path: /instance_groups/name=bosh/jobs/name=atc/properties/external_url
+  value: https://((concourse_lb_url))
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/name=atc/properties/generic_oauth/auth_url
+  value: "https://((bucc_concourse_lb_url)):8443/oauth/authorize"
+
+- type: replace
+  path: /variables/name=atc_ssl/options/alternative_names/-
+  value: ((concourse_lb_url))
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/clients/concourse/redirect-uri
+  value: https://((concourse_lb_url))/auth/oauth/callback
+
+# UAA
+- type: replace
+  path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/zones/internal/hostnames/-
+  value: ((concourse_lb_url))
+
+- type: replace
+  path: /variables/name=uaa_ssl/options/alternative_names/-
+  value: ((concourse_lb_url))
+
+- type: replace
+  path: /variables/name=uaa_service_provider_ssl/options/alternative_names/-
+  value: ((concourse_lb_url))

--- a/ops/flags/concourse-lb-url.yml
+++ b/ops/flags/concourse-lb-url.yml
@@ -5,7 +5,7 @@
 
 - type: replace
   path: /instance_groups/name=bosh/jobs/name=atc/properties/generic_oauth/auth_url
-  value: "https://((bucc_concourse_lb_url)):8443/oauth/authorize"
+  value: "https://((concourse_lb_url)):8443/oauth/authorize"
 
 - type: replace
   path: /variables/name=atc_ssl/options/alternative_names/-


### PR DESCRIPTION
This PR adds the ability to specify a concourse_lb_url, it also makes sure the uaa will work on the specified url. My goal was to keep the required changes to a minimum (to keep it maintainable).