### PR TITLE
Don't write bbl env vars to disk

### DIFF
--- a/bbl/common.sh
+++ b/bbl/common.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 vars_file="${BBL_STATE_DIR}/vars/director-vars-file.yml"
 flags_file="${BBL_STATE_DIR}/vars/flags"
+bucc_args=""
 
 add_var() {
-    echo "${1}: '${2}'" >> "${vars_file}"
+    bucc_args="${bucc_args} --var=${1}=${2}"
 }
 
-add_var_from_file() {
-    echo "${1}: |" >> "${vars_file}"
-    cat "${2}" | sed 's/^/  /g' >> "${vars_file}"
+add_var_file() {
+    bucc_args="${bucc_args} --var-file=${1}=${2}"
 }
 
 add_flag() {
-    echo "${1}" >> "${flags_file}"
+    bucc_args="${bucc_args} --${1}"
 }
 
 cpi() {
@@ -64,7 +64,7 @@ prepare_vars_file_for_cpi() {
             add_var "tenant_id" "${BBL_AZURE_TENANT_ID}"
             ;;
         gcp)
-            add_var_from_file "gcp_credentials_json" "${BBL_GCP_SERVICE_ACCOUNT_KEY_PATH}"
+            add_var_file "gcp_credentials_json" "${BBL_GCP_SERVICE_ACCOUNT_KEY_PATH}"
             add_var "project_id" "${BBL_GCP_PROJECT_ID}"
             add_var "zone" "${BBL_GCP_ZONE}"
             ;;

--- a/bbl/common.sh
+++ b/bbl/common.sh
@@ -49,6 +49,8 @@ set_default_cpi_flags() {
 apply_default_vars() {
     bosh int <(cat ${BBL_STATE_DIR}/bucc/ops/cpis/$(cpi)/vars.tmpl ${vars_file}) > ${vars_file}.tmp
     mv ${vars_file}.tmp ${vars_file}
+    cat ${vars_file} | grep -vI '.*: null$' > ${vars_file}.tmp
+    mv ${vars_file}.tmp ${vars_file}
 }
 
 prepare_vars_file_for_cpi() {

--- a/bbl/common.sh
+++ b/bbl/common.sh
@@ -20,30 +20,27 @@ cpi() {
 }
 
 set_default_cpi_flags() {
-    if [ ! -e "${flags_file}" ]; then
-       touch "${flags_file}"
-       case $(cpi) in
-           aws)
-              add_flag "auto-assign-public-ip"
-              add_flag "security-groups"
-              add_flag "lb-target-groups"
-              add_flag "concourse-lb"
-           ;;
-           azure)
-              add_flag "load-balancer"
-              add_flag "concourse-lb"
-           ;;
-           gcp)
-              add_flag "ephemeral-external-ip"
-              add_flag "target-pool"
-              add_flag "concourse-lb"
-           ;;
-           vsphere)
-           ;;
-           openstack)
-           ;;
-       esac
-    fi
+    case $(cpi) in
+        aws)
+            add_flag "auto-assign-public-ip"
+            add_flag "security-groups"
+            add_flag "lb-target-groups"
+            add_flag "concourse-lb"
+            ;;
+        azure)
+            add_flag "load-balancer"
+            add_flag "concourse-lb"
+            ;;
+        gcp)
+            add_flag "ephemeral-external-ip"
+            add_flag "target-pool"
+            add_flag "concourse-lb"
+            ;;
+        vsphere)
+            ;;
+        openstack)
+            ;;
+    esac
 }
 
 apply_default_vars() {

--- a/bbl/create-director-override.sh
+++ b/bbl/create-director-override.sh
@@ -5,4 +5,4 @@ source ./bucc/bbl/common.sh
 prepare_vars_file_for_cpi
 set_default_cpi_flags
 
-./bucc/bin/bucc up --cpi $(cpi)
+./bucc/bin/bucc up --cpi $(cpi) "${bucc_args}"

--- a/bbl/create-director-override.sh
+++ b/bbl/create-director-override.sh
@@ -5,4 +5,4 @@ source ./bucc/bbl/common.sh
 prepare_vars_file_for_cpi
 set_default_cpi_flags
 
-./bucc/bin/bucc up --cpi $(cpi) "${bucc_args}"
+./bucc/bin/bucc up --cpi $(cpi) ${bucc_args}

--- a/bbl/delete-director-override.sh
+++ b/bbl/delete-director-override.sh
@@ -5,4 +5,4 @@ source ./bucc/bbl/common.sh
 prepare_vars_file_for_cpi
 set_default_cpi_flags
 
-./bucc/bin/bucc down --cpi $(cpi) "${bucc_args}"
+./bucc/bin/bucc down --cpi $(cpi) ${bucc_args}

--- a/bbl/delete-director-override.sh
+++ b/bbl/delete-director-override.sh
@@ -5,4 +5,4 @@ source ./bucc/bbl/common.sh
 prepare_vars_file_for_cpi
 set_default_cpi_flags
 
-./bucc/bin/bucc down --cpi $(cpi)
+./bucc/bin/bucc down --cpi $(cpi) "${bucc_args}"

--- a/bin/bucc
+++ b/bin/bucc
@@ -228,7 +228,7 @@ up() {
     if [[ ${DEBUG} == true ]]; then
         echo -e "bosh create-env $(int_args | sed 's/yml/yml \\ \\n/g') ${state_arg}\n"
     fi
-    bosh create-env $(int_args) ${state_arg}
+    bosh create-env $(int_args) ${state_arg} ${1}
 }
 
 down() {
@@ -236,7 +236,7 @@ down() {
       echo "please create a enviroment first with 'bucc up'"
       exit 1
     fi
-    bosh delete-env $(int_args) $state_arg
+    bosh delete-env $(int_args) ${state_arg} ${1}
     echo "you can use the clean command if your are planning to use a new cpi or ip"
 }
 
@@ -526,6 +526,10 @@ case "$1" in
                 --debug)
                     DEBUG=true
                     ;;
+                --var=*|--var-file=*)
+                    bosh_args="${bosh_args} ${1}"
+                    shift
+                    ;;
                 *)
                     echo ${1#*--} >> ${state}/flags
             esac
@@ -536,7 +540,7 @@ case "$1" in
         validate_vars_file
         validate_cpi_flags
 
-        up "$@"
+        up "${bosh_args}"
         ;;
 
     down)
@@ -552,10 +556,14 @@ case "$1" in
                     clean
                     exit 0
                     ;;
+                --var=*|--var-file=*)
+                    bosh_args="${bosh_args} ${1}"
+                    shift
+                    ;;
             esac
             shift
         done
-        down
+        down "${bosh_args}"
         ;;
 
     clean)
@@ -590,9 +598,9 @@ case "$1" in
         ;;
 
     bbr)
-	shift
-	_bbr "$@"
-	;;
+        shift
+        _bbr "$@"
+        ;;
 
     ssh)
         shift

--- a/bin/bucc
+++ b/bin/bucc
@@ -228,7 +228,7 @@ up() {
     if [[ ${DEBUG} == true ]]; then
         echo -e "bosh create-env $(int_args | sed 's/yml/yml \\ \\n/g') ${state_arg}\n"
     fi
-    bosh create-env $(int_args) ${state_arg} ${1}
+    bosh create-env $(int_args) ${state_arg} "$@"
 }
 
 down() {
@@ -236,7 +236,7 @@ down() {
       echo "please create a enviroment first with 'bucc up'"
       exit 1
     fi
-    bosh delete-env $(int_args) ${state_arg} ${1}
+    bosh delete-env $(int_args) ${state_arg} "$@"
     echo "you can use the clean command if your are planning to use a new cpi or ip"
 }
 
@@ -506,6 +506,7 @@ _ensure_bosh_cli_installed
 case "$1" in
     up)
         shift
+        bosh_args=""
         while [[ $# -gt 0 ]]; do
             case "$1" in
                 -h|--help|help)
@@ -518,7 +519,6 @@ case "$1" in
                     ;;
                 --cpi=*)
                     echo "${1#*=}" > ${state}/cpi
-                    shift
                     ;;
                 --lite)
                     echo "true" > ${state}/lite
@@ -528,7 +528,6 @@ case "$1" in
                     ;;
                 --var=*|--var-file=*)
                     bosh_args="${bosh_args} ${1}"
-                    shift
                     ;;
                 *)
                     echo ${1#*--} >> ${state}/flags
@@ -540,11 +539,12 @@ case "$1" in
         validate_vars_file
         validate_cpi_flags
 
-        up "${bosh_args}"
+        up ${bosh_args}
         ;;
 
     down)
         shift
+        bosh_args=""
         while [[ $# -gt 0 ]]; do
             case "$1" in
                 -h|--help|help)
@@ -558,7 +558,6 @@ case "$1" in
                     ;;
                 --var=*|--var-file=*)
                     bosh_args="${bosh_args} ${1}"
-                    shift
                     ;;
             esac
             shift

--- a/ops/cpis/aws/vars.tmpl
+++ b/ops/cpis/aws/vars.tmpl
@@ -1,10 +1,10 @@
 director_name: # bucc
 # alias: bucc
-access_key_id: ...
-secret_access_key: ...
+access_key_id: # ...
+secret_access_key: # ...
 region: us-east-1
 az: us-east-1b
-subnet_id: subnet-...
+subnet_id: # subnet-...
 internal_cidr: 10.0.0.0/24
 internal_gw: 10.0.0.1
 internal_ip: 10.0.0.6
@@ -12,7 +12,7 @@ default_security_groups: [bosh]
 default_key_name: bosh
 private_key:
 
-instance_type:  m4.xlarge
+instance_type: m4.xlarge
 ephemeral_disk_size: 25_000
 
 # flag: --spot-instance

--- a/ops/cpis/gcp/vars.tmpl
+++ b/ops/cpis/gcp/vars.tmpl
@@ -1,17 +1,17 @@
 director_name: # bosh
-gcp_credentials_json: |
-  {
-    "type": "service_account",
-    "project_id": "myprojectid",
-    "private_key_id": "xxxxxxxxxxxxxxxxxxxx",
-    "private_key": "-----BEGIN PRIVATE KEY-----xxxxxxxxxx-----END PRIVATE KEY-----\n",
-    "client_email": "xxxxxxxxxxxxxxx.iam.gserviceaccount.com",
-    "client_id": "xxxxxxxxxxxxxx",
-    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-    "token_uri": "https://accounts.google.com/o/oauth2/token",
-    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/xxxxxxxxxxxxxxxx.iam.gserviceaccount.com"
-  }
+gcp_credentials_json: # |
+  # {
+  #   "type": "service_account",
+  #   "project_id": "myprojectid",
+  #   "private_key_id": "xxxxxxxxxxxxxxxxxxxx",
+  #   "private_key": "-----BEGIN PRIVATE KEY-----xxxxxxxxxx-----END PRIVATE KEY-----\n",
+  #   "client_email": "xxxxxxxxxxxxxxx.iam.gserviceaccount.com",
+  #   "client_id": "xxxxxxxxxxxxxx",
+  #   "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  #   "token_uri": "https://accounts.google.com/o/oauth2/token",
+  #   "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  #   "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/xxxxxxxxxxxxxxxx.iam.gserviceaccount.com"
+  # }
 internal_cidr: # 10.0.0.0/24
 internal_gw: # 10.0.0.1
 internal_ip: # 10.0.0.6


### PR DESCRIPTION
This PR allows passing vars with `--var` and `--var-file` to bucc up. Which are by bbl wrapper scripts.