### PR TITLE
 Fixed zone example for gcp cpi vars template file

### DIFF
--- a/ops/cpis/gcp/vars.tmpl
+++ b/ops/cpis/gcp/vars.tmpl
@@ -19,7 +19,7 @@ network: # default
 project_id: # moonlight-2389ry3
 subnetwork: # default
 tags: # [internal]
-zone: # us-east-1
+zone: # us-east4-a
 
 # flag: --service-account
 service_account: # service-account


### PR DESCRIPTION
* Switched `us-east-1` to `us-east4-a` as the suggested `us-east-1` will return an error from the CPI.