### PR TITLE
Add error checking for bosh cli installation

### DIFF
--- a/bin/bucc
+++ b/bin/bucc
@@ -421,10 +421,18 @@ _ensure_bosh_cli_installed() {
       pushd $(mktemp -d)
       if [ "$(platform)" == "darwin" ]; then
           curl -s -L >bosh "${url}-${version}-darwin-amd64"
+          if [[ $? != 0 ]]; then
+            echo "Unable to download the bosh CLI. Please check your internet connection and try again."
+            exit 1
+          fi
           chmod +x bosh
           mv bosh ${repo_root}/bin/
       else
           curl -s -L >bosh "${url}-${version}-linux-amd64"
+          if [[ $? != 0 ]]; then
+            echo "Unable to download the bosh CLI. Please check your internet connection and try again."
+            exit 1
+          fi
           chmod +x bosh
           mv bosh ${repo_root}/bin/
       fi


### PR DESCRIPTION
I had an issue where the bosh cli installation failed because I was on a corporate VPN that forces the use of a proxy, which was not set in my environment. Easy enough to fix, but the script just said that was installing the bosh cli and then exited cleanly. It wasn't until I looked at `bocc/bin/bosh` and saw that it was empty that I figured out what was going on.