### PR TITLE
Map concourse https port when using docker-cpi

### DIFF
--- a/ops/cpis/1-extra-ports.yml
+++ b/ops/cpis/1-extra-ports.yml
@@ -1,0 +1,9 @@
+- type: replace
+  path: /resource_pools/name=vms/cloud_properties/ports/-
+  value: 443/tcp # concourse
+- type: replace
+  path: /resource_pools/name=vms/cloud_properties/ports/-
+  value: 8844/tcp # credhub
+- type: replace
+  path: /resource_pools/name=vms/cloud_properties/ports/-
+  value: 8200/tcp # vault


### PR DESCRIPTION
Telling the docker-cpi to map port 443 will make concourse accessible from the host