### PR TITLE
switch priority of azure network security rule to avoid conflicts

### DIFF
--- a/bbl/terraform/azure/bucc_override.tf
+++ b/bbl/terraform/azure/bucc_override.tf
@@ -10,7 +10,7 @@ output "director__load_balancer" {
 # add vault port for jumpbox
 resource "azurerm_network_security_rule" "vault" {
   name                        = "${var.env_id}-vault"
-  priority                    = 204
+  priority                    = 300
   direction                   = "Inbound"
   access                      = "Allow"
   protocol                    = "Tcp"


### PR DESCRIPTION
changes the priority on the vault azure security group rule so it does not conflict