### PR TITLE
Fix proxy flag for non-lite deployment

### DIFF
--- a/ops/flags/proxy.yml
+++ b/ops/flags/proxy.yml
@@ -24,13 +24,13 @@
   value: ((internal_ip)),((no_proxy)) 
 
 - type: replace
-  path: /instance_groups/name=bosh/jobs/name=garden/properties/garden/http_proxy?
+  path: /instance_groups/name=bosh/jobs/name=garden?/properties/garden/http_proxy?
   value: ((http_proxy))
 
 - type: replace
-  path: /instance_groups/name=bosh/jobs/name=garden/properties/garden/https_proxy?
+  path: /instance_groups/name=bosh/jobs/name=garden?/properties/garden/https_proxy?
   value: ((https_proxy))
 
 - type: replace
-  path: /instance_groups/name=bosh/jobs/name=garden/properties/garden/no_proxy?
+  path: /instance_groups/name=bosh/jobs/name=garden?/properties/garden/no_proxy?
   value: 127.0.0.1,((internal_ip)),((no_proxy)) 


### PR DESCRIPTION
When not deploying with the `--lite` flag the garden job is missing which results in the error:
```
Parsing release set manifest '/var/vcap/store/home/jumpbox/workspace/vagrant/src/bucc/src/bosh-deployment/bosh.yml':
  Evaluating manifest:
    Expected to find exactly one matching array item for path '/instance_groups/name=bosh/jobs/name=garden' but found 0
```