### PR TITLE
Fix explicit keying of tls.{certificate,private_key} for vault-proxy

### DIFF
--- a/ops/4-vault-credhub-proxy.yml
+++ b/ops/4-vault-credhub-proxy.yml
@@ -12,7 +12,9 @@
     release: vault-credhub-proxy
     properties:
       address: ((internal_ip)):8200
-      tls: ((vault-proxy_tls))
+      tls:
+        certificate: ((vault-proxy_tls.certificate))
+        private_key: ((vault-proxy_tls.private_key))
       credhub:
         server: "https://((internal_ip)):8844"
         ca: ((credhub_tls.ca))((uaa_ssl.ca))


### PR DESCRIPTION
This fixes an issue when trying to deploy with credhub backend (instead of using an on disk file as a creds store)