### PR TITLE
Expose Template Variables for vSphere VM Size and Domain

### DIFF
--- a/ops/cpis/vsphere/vars.tmpl
+++ b/ops/cpis/vsphere/vars.tmpl
@@ -22,3 +22,6 @@ vcenter_dns: # [ 8.8.4.4 ]
 
 # flag: --resource-pool
 vcenter_rp: # my-bosh-rp
+
+# flag: --concourse-lb
+concourse_domain: # ci.foo.com

--- a/ops/cpis/vsphere/vars.tmpl
+++ b/ops/cpis/vsphere/vars.tmpl
@@ -13,6 +13,9 @@ vcenter_password: # vmware
 vcenter_templates: # bosh-1-templates
 vcenter_user: # root
 vcenter_vms: # bosh-1-vms
+vcenter_vm_cpu: 4
+vcenter_vm_disk: 50000
+vcenter_vm_ram: 16640
 
 # flag: --dns
 vcenter_dns: # [ 8.8.4.4 ]

--- a/ops/cpis/vsphere/vm-size.yml
+++ b/ops/cpis/vsphere/vm-size.yml
@@ -1,6 +1,6 @@
 - type: replace
   path: /resource_pools/name=vms/cloud_properties?
   value:
-    cpu: ((vcenter_vm_cpu)
+    cpu: ((vcenter_vm_cpu))
     disk: ((vcenter_vm_disk))
     ram: ((vcenter_vm_ram))

--- a/ops/cpis/vsphere/vm-size.yml
+++ b/ops/cpis/vsphere/vm-size.yml
@@ -1,7 +1,6 @@
 - type: replace
   path: /resource_pools/name=vms/cloud_properties?
   value:
-    cpu: 4
-    disk: 50000
-    ram: 16640
-      
+    cpu: ((vcenter_vm_cpu)
+    disk: ((vcenter_vm_disk))
+    ram: ((vcenter_vm_ram))


### PR DESCRIPTION
I use BUCC to setup a control plane for Pivotal Platform Automation. However, the default VM disk size is too small and the disk keeps filling up. This lead me to #182 - which is exactly the issue I'm facing. This PR exposes variables that can be used to customize the VM.

Additionally, this PR adds a template variable to be used by the `--concourse-lb` flag. I had to do a bit of code searching to figure out how to use this flag, so I thought a template variable would make this easier for others.
