### PR TITLE
Revert "Fix alias check"

### DIFF
--- a/bin/bucc
+++ b/bin/bucc
@@ -338,13 +338,11 @@ get_var_with_default() {
     if [[ ! -f ${var_cache} ]]; then
         vars > ${var_cache}
     fi
-    local value=$(bosh int ${var_cache} --path "/$path" 2>/dev/null)
-    if [[ $? -eq 0 ]]; then
-        echo "${value}"
+    if [[ -n $(cat ${var_cache} | grep "$path:") ]]; then
+        bosh int ${var_cache} --path "/$path"
     else
         echo "${default_value}"
     fi
-
 }
 
 _alias() {


### PR DESCRIPTION
Reverts starkandwayne/bucc#209

```
    local value=$(bosh int ${var_cache} --path "/$path" 2>/dev/null)	    
     if [[ $? -eq 0 ]]; then
        echo "${value}"
```
`2>/dev/null is a redirect and always gives a 0 exit status code.
so ` eq=0` is alwasy used. 